### PR TITLE
Add linting support for Windows and src/visualization

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude = config, .venv, logs, data, src/features/compute_frustration.R
+exclude = config, .venv, logs, data, src/features/compute_frustration.R, src/hpc
 max-line-length = 120
 extend-ignore = E203, E402

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,6 @@ jobs:
             run: poetry run mypy
           - name: Lint with flake8
             run: |
-                poetry run flake8 src/data/*
-                poetry run flake8 src/features/*
+                poetry run flake8 src
                 poetry run flake8 tests
               


### PR DESCRIPTION
This PR addresses the following issues:

- (#58) Lints the whole src directory, removing path delimiters
- (#59) By linting the whole src directory, also lints the visualization directory too